### PR TITLE
added unit test test-1-get-zcta-crosswalk to the package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,3 +18,6 @@ Imports:
 Depends:
     R (>= 3.5.0)
 RoxygenNote: 7.2.3
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(zctaCrosswalk)
+
+test_check("zctaCrosswalk")

--- a/tests/testthat/test-1-get-zcta-crosswalk.R
+++ b/tests/testthat/test-1-get-zcta-crosswalk.R
@@ -1,0 +1,9 @@
+context("Fetch Census Bureau's 2020 ZCTA Country Relationship file as a tibble")
+
+test_that("standard get_zcta_crosswalk()", {
+  fetch_data <- get_zcta_crosswalk()
+  
+  expect_equal(nrow(fetch_data), 46960)
+  expect_equal(ncol(fetch_data), 4)
+  expect_equal(colnames(fetch_data), c("zcta", "county_fips", "county_name", "state_fips"))
+})

--- a/zctaCrosswalk.Rproj
+++ b/zctaCrosswalk.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
This PR include the following:

- The creation of the tests folder and testhat subfolder
- Within the tests folder there is a testhat.R which is a standard add on to the folder
-  Within  the testthat subfolder there is the test-1-get-zcta-crosswalk   
